### PR TITLE
Add automatic deps generation for Qt libraries in Linux

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -77,6 +77,7 @@ load("@com_github_kklochkov_rules_qt//qt:qt_local_repo.bzl", "qt_local_repo")
 
 qt_local_repo(
     name = "qt",
+    infer_deps = True,
     # Linux
     #path = "/usr/lib/qt5",
     #path = "/usr/lib/qt6",


### PR DESCRIPTION
Implementation of a new feature that allows the `qt_local_repo` rule to analyze the `.so` files from Qt libraries to determine which other Qt libraries they depend on, and add them to the `deps` parameter of the generated `cc_library` targets.

This feature is controlled by a new attribute `infer_deps`, which defaults to False.

This has two caveats:
1. For the moment it is implemented only for Linux, using `ldd` (although it is possible in macOS as well, and I might do it in the near future)
2. It does not distinguish between optional and non-optional dependencies.

For example, in Qt6.5 the `Quick3D` module has an optional dependency on `ShaderTools`. It still works if `ShaderTools` is not installed, but because `ShaderTools` is linked to it (and there is no way to know optional dependencies before runtime) it is added as a dependency. This means users who use this feature will need to install all optional dependencies for the modules they have already installed.