### PR TITLE
fix: sort includes for correct caching

### DIFF
--- a/qt/qt_local_repo.bzl
+++ b/qt/qt_local_repo.bzl
@@ -398,7 +398,7 @@ def _qt_local_repo_impl(repository_ctx):
         content.append(_BUILD_CONTENT_CC_TARGET_EPILOGUE)
 
     # add last bits
-    content.append(_BUILD_CONTENT_CC_TARGET_ALL_HEADERS.format(includes = _join_includes(qtconf, qt_libs_context.keys())))
+    content.append(_BUILD_CONTENT_CC_TARGET_ALL_HEADERS.format(includes = _join_includes(qtconf, sorted(qt_libs_context.keys()))))
     content.append(_BUILD_CONTENT_EPILOGUE)
 
     repository_ctx.file("BUILD.bazel", "\n".join(content))


### PR DESCRIPTION
`readdir` does not seem to guarantee any ordering, and iterating over a `dict` retrieves the keys in an order that depends on insertion order. This causes the command line action for `moc_hdrs`/`moc_srcs` to have different flag ordering depending on the environment, which modifies cache keys.

This simple fix sorts the keys retrieved from the dict so that the command line is always the same (as long as the headers are the same) and cache is hit.