### PR TITLE
fix: support Bazel 9 by loading CcInfo, cc_binary, and cc_library

### DIFF
--- a/qt/defs.bzl
+++ b/qt/defs.bzl
@@ -1,5 +1,6 @@
 """A set of convenience macros for using Qt's rules with Bazel."""
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load(":private/balsam.bzl", "balsam")
 load(":private/moc.bzl", "moc_hdrs", "moc_srcs")
 load(":private/qml.bzl", "qml_module")
@@ -111,7 +112,7 @@ def qt_cc_library(
       **kwargs: Additional arguments for `cc_library` rule.
     """
     _qt_cc_target(
-        native.cc_library,
+        cc_library,
         name,
         srcs,
         deps,
@@ -256,7 +257,7 @@ def qt_cc_binary(
         fail("qt_cc_binary: compatibility target name collision for '{target}'".format(target = compat_name))
 
     _qt_cc_target(
-        native.cc_binary,
+        cc_binary,
         inner_name,
         srcs,
         deps,

--- a/qt/private/moc.bzl
+++ b/qt/private/moc.bzl
@@ -1,5 +1,6 @@
 """Rules that allow to use [Qt's moc](https://doc.qt.io/qt-5/moc.html) with Bazel."""
 
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(":private/utils.bzl", "MocInfo", "QT_TOOLCHAIN")
 
 def _moc_hdrs_impl(ctx):

--- a/qt/private/uic.bzl
+++ b/qt/private/uic.bzl
@@ -1,5 +1,6 @@
 """Rules that allow to use [Qt's uic](https://doc.qt.io/qt-5/uic.html) with Bazel."""
 
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(":private/utils.bzl", "QT_TOOLCHAIN")
 
 def _uic_impl(ctx):


### PR DESCRIPTION
Bazel 9 removed the global CcInfo provider from native and the same for cc_binary and cc_library rules. Now there are required to load them explicitly. 